### PR TITLE
Proposed fix TilCreator/Tapas-Comic-Downloader#17

### DIFF
--- a/tapas-dl.py
+++ b/tapas-dl.py
@@ -151,7 +151,7 @@ for urlCount, url in enumerate(args.url):
 
             pageData['imgs'] = []
             for img in pageHtml('.content__img'):
-                pageData['imgs'].append(pq(img).attr('src'))
+                pageData['imgs'].append(pq(img).attr('data-src'))
 
                 allImgCount += 1
 


### PR DESCRIPTION
Appears to fix the "ValueError: substring not found" for line 164.